### PR TITLE
V0.21.0 jd mtp rtt

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -3,6 +3,7 @@
 import dataclasses
 from unittest.mock import Mock
 
+import numpy as np
 import pytest
 import torch
 
@@ -32,7 +33,12 @@ from vllm.v1.kv_cache_interface import (
     KVCacheConfig,
     KVCacheGroupSpec,
 )
-from vllm.v1.outputs import DraftTokenIds, KVConnectorOutput, ModelRunnerOutput
+from vllm.v1.outputs import (
+    DraftTokenIds,
+    KVConnectorOutput,
+    LogprobsLists,
+    ModelRunnerOutput,
+)
 from vllm.v1.request import Request, RequestStatus
 from vllm.v1.structured_output import StructuredOutputManager
 
@@ -4288,3 +4294,295 @@ def test_eagle3_mm_encoder_cache_with_shift():
         f"shifted_end={scheduled_end_with_shift}) overlapping MM at "
         f"{start_pos}. The fix must schedule encoder inputs."
     )
+
+
+# ---------------------------------------------------------------------------
+# Jump-forward decoding tests
+# ---------------------------------------------------------------------------
+
+
+def _setup_jump_forward_request(scheduler, request, opt_in: bool = True):
+    """Put a request into RUNNING state with prefill done.
+
+    By default opts the request into jump decoding by setting
+    ``sampling_params.structured_outputs.enable_jump_decoding = True``.
+    Set opt_in=False to exercise the per-request opt-out path.
+    """
+    request.num_computed_tokens = request.num_tokens
+    request.status = RequestStatus.RUNNING
+    scheduler.requests[request.request_id] = request
+    scheduler.running.append(request)
+    request.sampling_params.structured_outputs = Mock(enable_jump_decoding=opt_in)
+
+
+def _make_mock_grammar(ff_tokens: list[int]):
+    grammar = Mock()
+    grammar.accept_tokens = Mock(return_value=True)
+    grammar.is_terminated = Mock(return_value=False)
+    grammar.advance_ff_tokens = Mock(return_value=ff_tokens)
+    return grammar
+
+
+def _make_structured_output_request(grammar):
+    sor = Mock()
+    sor.grammar = grammar
+    sor.reasoning_ended = None
+    return sor
+
+
+def _empty_scheduler_output(req_id, num_tokens=1):
+    return SchedulerOutput(
+        scheduled_new_reqs=[],
+        scheduled_cached_reqs=CachedRequestData.make_empty(),
+        num_scheduled_tokens={req_id: num_tokens},
+        total_num_scheduled_tokens=num_tokens,
+        scheduled_encoder_inputs={},
+        scheduled_spec_decode_tokens={},
+        num_common_prefix_blocks=[],
+        finished_req_ids=set(),
+        free_encoder_mm_hashes=[],
+    )
+
+
+def test_jump_forward_tokens_injected():
+    """ff_tokens from grammar are appended to the request and stored in
+    pending_ff_tokens."""
+    scheduler = create_scheduler(enable_jump_decoding=True)
+    scheduler.structured_output_manager.should_advance = Mock(return_value=True)
+
+    requests = create_requests(num_requests=1, max_tokens=20)
+    req = requests[0]
+    _setup_jump_forward_request(scheduler, req)
+
+    grammar = _make_mock_grammar([100, 101, 102])
+    req.structured_output_request = _make_structured_output_request(grammar)
+
+    scheduler_output = _empty_scheduler_output(req.request_id)
+    model_output = ModelRunnerOutput(
+        req_ids=[req.request_id],
+        req_id_to_index={req.request_id: 0},
+        sampled_token_ids=[[7]],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+
+    scheduler.update_from_output(scheduler_output, model_output)
+
+    # Sampled token (7) followed by all three ff_tokens.
+    assert list(req.output_token_ids) == [7, 100, 101, 102]
+    assert scheduler.pending_ff_tokens[req.request_id] == [100, 101, 102]
+    assert not req.is_finished()
+
+
+def test_jump_forward_tokens_stop_eos():
+    """ff_tokens containing EOS truncate the sequence and stop the request."""
+    scheduler = create_scheduler(enable_jump_decoding=True)
+    scheduler.structured_output_manager.should_advance = Mock(return_value=True)
+
+    requests = create_requests(num_requests=1, max_tokens=20)
+    req = requests[0]
+    _setup_jump_forward_request(scheduler, req)
+
+    grammar = _make_mock_grammar([100, EOS_TOKEN_ID, 102])
+    req.structured_output_request = _make_structured_output_request(grammar)
+
+    scheduler_output = _empty_scheduler_output(req.request_id)
+    model_output = ModelRunnerOutput(
+        req_ids=[req.request_id],
+        req_id_to_index={req.request_id: 0},
+        sampled_token_ids=[[7]],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+
+    scheduler.update_from_output(scheduler_output, model_output)
+
+    assert list(req.output_token_ids) == [7, 100, EOS_TOKEN_ID]
+    assert req.status == RequestStatus.FINISHED_STOPPED
+    assert scheduler.pending_ff_tokens[req.request_id] == [100, EOS_TOKEN_ID]
+    # Stop cleanup must run for FF-triggered stops: request is gone from
+    # the running queue and finished_req_ids tracks it.
+    assert req not in scheduler.running
+    assert req.request_id in scheduler.finished_req_ids
+
+
+def test_jump_forward_tokens_stop_max_tokens():
+    """ff_tokens exceeding max_tokens truncate the sequence and stop the
+    request with FINISHED_LENGTH_CAPPED."""
+    scheduler = create_scheduler(enable_jump_decoding=True)
+    scheduler.structured_output_manager.should_advance = Mock(return_value=True)
+
+    # max_tokens=3 so after the sampled token (1), only 2 ff tokens fit.
+    requests = create_requests(num_requests=1, max_tokens=3)
+    req = requests[0]
+    _setup_jump_forward_request(scheduler, req)
+
+    grammar = _make_mock_grammar([100, 101, 102, 103])
+    req.structured_output_request = _make_structured_output_request(grammar)
+
+    scheduler_output = _empty_scheduler_output(req.request_id)
+    model_output = ModelRunnerOutput(
+        req_ids=[req.request_id],
+        req_id_to_index={req.request_id: 0},
+        sampled_token_ids=[[7]],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+
+    scheduler.update_from_output(scheduler_output, model_output)
+
+    assert list(req.output_token_ids) == [7, 100, 101]
+    assert req.status == RequestStatus.FINISHED_LENGTH_CAPPED
+    assert req not in scheduler.running
+    assert req.request_id in scheduler.finished_req_ids
+
+
+def test_jump_forward_tokens_retain_unscheduled():
+    """pending_ff_tokens for a request not scheduled in the current step
+    must be preserved across steps."""
+    scheduler = create_scheduler(enable_jump_decoding=True)
+    scheduler.structured_output_manager.should_advance = Mock(return_value=True)
+
+    requests = create_requests(num_requests=1, max_tokens=20)
+    req = requests[0]
+    _setup_jump_forward_request(scheduler, req)
+    scheduler.pending_ff_tokens[req.request_id] = [42, 43]
+
+    # Schedule a different request id so this one is not scheduled.
+    other = "other-req"
+    scheduler.pending_ff_tokens[other] = [99]
+
+    scheduler_output = _empty_scheduler_output(req.request_id)
+    # Step the scheduler so it builds outputs; we only care that the
+    # `other` request's tokens are retained for a later step.
+    # Simulate the schedule() path by directly checking _filter logic via
+    # internal API would be too invasive — assert state after a call.
+    # Use a no-op model output for the scheduled request.
+    model_output = ModelRunnerOutput(
+        req_ids=[req.request_id],
+        req_id_to_index={req.request_id: 0},
+        sampled_token_ids=[[7]],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+    # `update_from_output` doesn't touch pending_ff_tokens for `other`.
+    scheduler.update_from_output(scheduler_output, model_output)
+
+    assert scheduler.pending_ff_tokens.get(other) == [99]
+
+
+def test_jump_forward_tokens_logprobs():
+    """When logprobs are requested, ff_tokens get synthetic logprob entries
+    (logprob=0.0 for the deterministic token, -inf for the rest)."""
+    scheduler = create_scheduler(enable_jump_decoding=True)
+    scheduler.structured_output_manager.should_advance = Mock(return_value=True)
+
+    requests = create_requests(num_requests=1, max_tokens=20)
+    req = requests[0]
+    _setup_jump_forward_request(scheduler, req)
+    req.sampling_params.logprobs = 3
+
+    grammar = _make_mock_grammar([100, 101, 102])
+    req.structured_output_request = _make_structured_output_request(grammar)
+
+    scheduler_output = _empty_scheduler_output(req.request_id)
+
+    sampled_token_ids = np.array([[7, 10, 11, 12]], dtype=np.int32)
+    sampled_logprobs = np.array([[-0.5, -1.0, -2.0, -3.0]], dtype=np.float32)
+    sampled_ranks = np.array([1], dtype=np.int32)
+    logprobs = LogprobsLists(sampled_token_ids, sampled_logprobs, sampled_ranks, None)
+
+    model_output = ModelRunnerOutput(
+        req_ids=[req.request_id],
+        req_id_to_index={req.request_id: 0},
+        sampled_token_ids=[[7]],
+        logprobs=logprobs,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+
+    engine_outputs = scheduler.update_from_output(scheduler_output, model_output)
+
+    output = engine_outputs[req.client_index].outputs[0]
+    assert output.new_token_ids == [7, 100, 101, 102]
+
+    lp = output.new_logprobs
+    assert lp is not None
+    assert lp.logprob_token_ids.shape[0] == 4
+    assert lp.logprobs.shape[0] == 4
+    assert lp.sampled_token_ranks.shape[0] == 4
+
+    # First row: original sampled logprobs.
+    assert lp.logprob_token_ids[0, 0] == 7
+    np.testing.assert_allclose(lp.logprobs[0, 0], -0.5)
+
+    # ff_token rows: column 0 holds the deterministic token with logprob 0.0.
+    # Columns 1+ have -inf (no real alternative) and -1 as the invalid
+    # token-id sentinel — guarantees no spurious {0: -inf} downstream.
+    for i, tok in enumerate([100, 101, 102], start=1):
+        assert lp.logprob_token_ids[i, 0] == tok
+        assert lp.logprobs[i, 0] == 0.0
+        assert np.all(np.isneginf(lp.logprobs[i, 1:]))
+        assert np.all(lp.logprob_token_ids[i, 1:] == -1)
+
+
+def test_jump_decoding_rejected_when_server_jd_disabled():
+    """Per-request enable_jump_decoding=True against a server that does NOT
+    have enable_jump_decoding in its --structured-outputs-config must raise.
+    Silently accepting and ignoring the flag would mask deployment-config
+    errors as performance regressions."""
+    from vllm.config.structured_outputs import StructuredOutputsConfig
+    from vllm.sampling_params import StructuredOutputsParams
+
+    sp = SamplingParams(
+        structured_outputs=StructuredOutputsParams(
+            json="{}", enable_jump_decoding=True
+        ),
+    )
+    # Case 1: server has structured_outputs configured but JD off.
+    so_config_off = StructuredOutputsConfig(
+        backend="guidance", enable_jump_decoding=False
+    )
+    with pytest.raises(ValueError, match="enable_jump_decoding"):
+        sp._validate_structured_outputs(
+            structured_outputs_config=so_config_off, tokenizer=None
+        )
+    # Case 2: server has no structured_outputs config at all.
+    with pytest.raises(ValueError, match="enable_jump_decoding"):
+        sp._validate_structured_outputs(
+            structured_outputs_config=None, tokenizer=None
+        )
+
+
+def test_jump_forward_skipped_when_request_opts_out():
+    """Server enables JD but request does not opt in — no FF tokens."""
+    scheduler = create_scheduler(enable_jump_decoding=True)
+    scheduler.structured_output_manager.should_advance = Mock(return_value=True)
+
+    requests = create_requests(num_requests=1, max_tokens=20)
+    req = requests[0]
+    _setup_jump_forward_request(scheduler, req, opt_in=False)
+
+    grammar = _make_mock_grammar([100, 101, 102])
+    req.structured_output_request = _make_structured_output_request(grammar)
+
+    scheduler_output = _empty_scheduler_output(req.request_id)
+    model_output = ModelRunnerOutput(
+        req_ids=[req.request_id],
+        req_id_to_index={req.request_id: 0},
+        sampled_token_ids=[[7]],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+
+    scheduler.update_from_output(scheduler_output, model_output)
+
+    # Only the sampled token; the grammar's ff_tokens were not consumed.
+    assert list(req.output_token_ids) == [7]
+    assert req.request_id not in scheduler.pending_ff_tokens
+    grammar.advance_ff_tokens.assert_not_called()

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -4530,6 +4530,112 @@ def test_jump_forward_tokens_logprobs():
         assert np.all(lp.logprob_token_ids[i, 1:] == -1)
 
 
+def test_spec_drafts_dropped_when_request_opts_out():
+    """Proposer-produced drafts are discarded for requests that did not
+    opt into speculative decoding."""
+    scheduler = create_scheduler()
+    requests = create_requests(num_requests=1, max_tokens=20)
+    req = requests[0]
+    req.num_computed_tokens = req.num_tokens
+    req.status = RequestStatus.RUNNING
+    scheduler.requests[req.request_id] = req
+    scheduler.running.append(req)
+    # No opt-in (default None).
+    req.sampling_params.enable_speculative_decoding = None
+
+    scheduler.update_draft_token_ids(
+        DraftTokenIds(req_ids=[req.request_id], draft_token_ids=[[100, 101]])
+    )
+
+    assert req.spec_token_ids == []
+
+
+def test_spec_drafts_dropped_when_request_opts_out_async_path():
+    """Async-scheduling counterpart: drafts in
+    scheduler_output.scheduled_spec_decode_tokens are overwritten with -1
+    sentinels (and counted as invalid) when the request did not opt into
+    speculative decoding. This exercises update_draft_token_ids_in_output,
+    the entry point used by step_with_batch_queue."""
+    scheduler = create_scheduler()
+    requests = create_requests(num_requests=1, max_tokens=20)
+    req = requests[0]
+    req.num_computed_tokens = req.num_tokens
+    req.status = RequestStatus.RUNNING
+    scheduler.requests[req.request_id] = req
+    scheduler.running.append(req)
+    # No opt-in (default None).
+    req.sampling_params.enable_speculative_decoding = None
+
+    scheduler_output = SchedulerOutput(
+        scheduled_new_reqs=[],
+        scheduled_cached_reqs=CachedRequestData.make_empty(),
+        num_scheduled_tokens={req.request_id: 1},
+        total_num_scheduled_tokens=1,
+        scheduled_spec_decode_tokens={req.request_id: [100, 101, 102]},
+        scheduled_encoder_inputs={},
+        num_common_prefix_blocks=[],
+        finished_req_ids=set(),
+        free_encoder_mm_hashes=[],
+    )
+
+    scheduler.update_draft_token_ids_in_output(
+        DraftTokenIds(
+            req_ids=[req.request_id], draft_token_ids=[[100, 101, 102]]
+        ),
+        scheduler_output,
+    )
+
+    assert scheduler_output.scheduled_spec_decode_tokens[req.request_id] == [
+        -1,
+        -1,
+        -1,
+    ]
+    assert scheduler_output.num_invalid_spec_tokens is not None
+    assert scheduler_output.num_invalid_spec_tokens[req.request_id] == 3
+
+
+def test_spec_drafts_kept_when_request_opts_in():
+    """Drafts are stored on the request when it explicitly opts in."""
+    scheduler = create_scheduler()
+    requests = create_requests(num_requests=1, max_tokens=20)
+    req = requests[0]
+    req.num_computed_tokens = req.num_tokens
+    req.status = RequestStatus.RUNNING
+    scheduler.requests[req.request_id] = req
+    scheduler.running.append(req)
+    req.sampling_params.enable_speculative_decoding = True
+
+    scheduler.update_draft_token_ids(
+        DraftTokenIds(req_ids=[req.request_id], draft_token_ids=[[100, 101]])
+    )
+
+    assert req.spec_token_ids == [100, 101]
+
+
+def test_jd_and_spec_mutex_per_request():
+    """A single request cannot enable both jump decoding and speculative
+    decoding — _validate_spec_decode rejects it."""
+    from vllm.sampling_params import StructuredOutputsParams
+
+    sp = SamplingParams(
+        enable_speculative_decoding=True,
+        structured_outputs=StructuredOutputsParams(
+            json="{}", enable_jump_decoding=True
+        ),
+    )
+    with pytest.raises(ValueError, match="cannot both be"):
+        sp._validate_spec_decode(speculative_config=None)
+
+
+def test_spec_decoding_rejected_when_server_has_no_spec_config():
+    """Per-request enable_speculative_decoding=True against a server that
+    was not started with --speculative-config must raise — silently
+    accepting and ignoring it masks deployment-config errors."""
+    sp = SamplingParams(enable_speculative_decoding=True)
+    with pytest.raises(ValueError, match="no SpeculativeConfig"):
+        sp._validate_spec_decode(speculative_config=None)
+
+
 def test_jump_decoding_rejected_when_server_jd_disabled():
     """Per-request enable_jump_decoding=True against a server that does NOT
     have enable_jump_decoding in its --structured-outputs-config must raise.

--- a/tests/v1/core/utils.py
+++ b/tests/v1/core/utils.py
@@ -12,6 +12,7 @@ from vllm.config import (
     ParallelConfig,
     SchedulerConfig,
     SpeculativeConfig,
+    StructuredOutputsConfig,
     VllmConfig,
 )
 from vllm.multimodal.inputs import (
@@ -57,6 +58,7 @@ def create_scheduler(
     pipeline_parallel_size: int = 1,
     use_ec_connector: bool = False,
     ec_role: str | None = None,
+    enable_jump_decoding: bool = False,
 ) -> Scheduler | AsyncScheduler:
     """Create scheduler under test.
 
@@ -135,6 +137,11 @@ def create_scheduler(
         else None
     )
 
+    structured_outputs_config = StructuredOutputsConfig(
+        backend="guidance" if enable_jump_decoding else "auto",
+        enable_jump_decoding=enable_jump_decoding,
+    )
+
     vllm_config = VllmConfig(
         scheduler_config=scheduler_config,
         model_config=model_config,
@@ -143,6 +150,7 @@ def create_scheduler(
         kv_transfer_config=kv_transfer_config,
         speculative_config=speculative_config,
         ec_transfer_config=ec_transfer_config,
+        structured_outputs_config=structured_outputs_config,
     )
     kv_cache_config = KVCacheConfig(
         num_blocks=num_blocks,  # A large number of blocks to hold all requests

--- a/vllm/config/structured_outputs.py
+++ b/vllm/config/structured_outputs.py
@@ -40,6 +40,11 @@ class StructuredOutputsConfig:
     loaded and registered."""
     enable_in_reasoning: bool = False
     """Whether to use structured input for reasoning."""
+    enable_jump_decoding: bool = False
+    """If True, enable jump-forward decoding for structured outputs.
+    When the grammar forces a deterministic sequence of tokens, they are
+    injected without model inference. Only supported with the guidance
+    backend."""
 
     def compute_hash(self) -> str:
         """
@@ -70,5 +75,9 @@ class StructuredOutputsConfig:
             raise ValueError(
                 "disable_additional_properties is only supported "
                 "for the guidance backend."
+            )
+        if self.enable_jump_decoding and self.backend != "guidance":
+            raise ValueError(
+                "enable_jump_decoding is only supported for the guidance backend."
             )
         return self

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -888,6 +888,15 @@ class VllmConfig:
             "enabled" if self.scheduler_config.async_scheduling else "disabled",
         )
 
+        if (
+            self.speculative_config is not None
+            and self.structured_outputs_config.enable_jump_decoding
+        ):
+            raise ValueError(
+                "Jump-forward decoding cannot be used together with "
+                "speculative decoding."
+            )
+
         if self.parallel_config.disable_nccl_for_dp_synchronization is None:
             if self.scheduler_config.async_scheduling:
                 if self.parallel_config.data_parallel_size > 1 and (

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -888,14 +888,10 @@ class VllmConfig:
             "enabled" if self.scheduler_config.async_scheduling else "disabled",
         )
 
-        if (
-            self.speculative_config is not None
-            and self.structured_outputs_config.enable_jump_decoding
-        ):
-            raise ValueError(
-                "Jump-forward decoding cannot be used together with "
-                "speculative decoding."
-            )
+        # Jump decoding and speculative decoding are now per-request opt-in
+        # (SamplingParams.structured_outputs.enable_jump_decoding and
+        # SamplingParams.enable_speculative_decoding). Mutual exclusion is
+        # enforced at the request level — see SamplingParams validation.
 
         if self.parallel_config.disable_nccl_for_dp_synchronization is None:
             if self.scheduler_config.async_scheduling:

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -381,6 +381,16 @@ class ChatCompletionRequest(OpenAIBaseModel):
             "len(token_texts) == len(token_ids) when both are requested."
         ),
     )
+    enable_speculative_decoding: bool | None = Field(
+        default=None,
+        description=(
+            "Per-request opt-in for speculative decoding. Requires the "
+            "server to have --speculative-config set. If unset/false, "
+            "proposer-produced drafts are discarded for this request. "
+            "Mutually exclusive with "
+            "structured_outputs.enable_jump_decoding."
+        ),
+    )
 
     cache_salt: str | None = Field(
         default=None,
@@ -620,6 +630,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
             if self.stream
             else RequestOutputKind.FINAL_ONLY,
             return_token_texts=bool(self.return_token_texts),
+            enable_speculative_decoding=self.enable_speculative_decoding,
             structured_outputs=self.structured_outputs,
             logit_bias=self.logit_bias,
             bad_words=self.bad_words,

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -92,6 +92,7 @@ class ChatCompletionResponseChoice(OpenAIBaseModel):
     # not part of the OpenAI spec but is useful for tracing the tokens
     # in agent scenarios
     token_ids: list[int] | None = None
+    token_texts: list[str] | None = None
     routed_experts: list[list[list[int]]] | None = None  # [gen_len, num_layers, top_k]
 
 
@@ -127,6 +128,7 @@ class ChatCompletionResponseStreamChoice(OpenAIBaseModel):
     stop_reason: int | str | None = None
     # not part of the OpenAI spec but for tracing the tokens
     token_ids: list[int] | None = None
+    token_texts: list[str] | None = None
 
 
 class ChatCompletionStreamResponse(OpenAIBaseModel):
@@ -367,6 +369,18 @@ class ChatCompletionRequest(OpenAIBaseModel):
             "exactly what was fed into the model."
         ),
     )
+    return_token_texts: bool | None = Field(
+        default=None,
+        description=(
+            "If specified, the result will include per-token detokenized "
+            "strings produced by contextual incremental detokenization. "
+            "Each entry corresponds to one token and represents its text "
+            "contribution to the generated output. "
+            "Invariant: ''.join(token_texts) == delta.content (streaming) "
+            "or ''.join(token_texts) == message.content (non-streaming). "
+            "len(token_texts) == len(token_ids) when both are requested."
+        ),
+    )
 
     cache_salt: str | None = Field(
         default=None,
@@ -605,6 +619,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
             output_kind=RequestOutputKind.DELTA
             if self.stream
             else RequestOutputKind.FINAL_ONLY,
+            return_token_texts=bool(self.return_token_texts),
             structured_outputs=self.structured_outputs,
             logit_bias=self.logit_bias,
             bad_words=self.bad_words,

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -752,12 +752,14 @@ class OpenAIServingChat(OpenAIServing):
                     # wasn't ready to send a token, then
                     #   get the next token without streaming a chunk
                     if delta_message is None:
-                        # NOTE: If return_token_ids is enabled, we still need to
-                        # send a chunk with token_ids even if delta_message is None
-                        # to ensure all tokens are included in the response
+                        # NOTE: If return_token_ids or return_token_texts is
+                        # enabled, we still need to send a chunk even if
+                        # delta_message is None to ensure all tokens are
+                        # included in the response.
                         if (
                             output.finish_reason is None
                             and not request.return_token_ids
+                            and not request.return_token_texts
                         ):
                             continue
                         delta_message = DeltaMessage()
@@ -800,6 +802,11 @@ class OpenAIServingChat(OpenAIServing):
                             token_ids=(
                                 as_list(output.token_ids)
                                 if request.return_token_ids
+                                else None
+                            ),
+                            token_texts=(
+                                output.token_texts
+                                if request.return_token_texts
                                 else None
                             ),
                         )
@@ -900,6 +907,11 @@ class OpenAIServingChat(OpenAIServing):
                             token_ids=(
                                 as_list(output.token_ids)
                                 if request.return_token_ids
+                                else None
+                            ),
+                            token_texts=(
+                                output.token_texts
+                                if request.return_token_texts
                                 else None
                             ),
                         )
@@ -1100,6 +1112,9 @@ class OpenAIServingChat(OpenAIServing):
                     stop_reason=output.stop_reason,
                     token_ids=(
                         as_list(output.token_ids) if request.return_token_ids else None
+                    ),
+                    token_texts=(
+                        output.token_texts if request.return_token_texts else None
                     ),
                     routed_experts=(
                         output.routed_experts.tolist()
@@ -1326,6 +1341,9 @@ class OpenAIServingChat(OpenAIServing):
                 stop_reason=output.stop_reason,
                 token_ids=(
                     as_list(output.token_ids) if request.return_token_ids else None
+                ),
+                token_texts=(
+                    output.token_texts if request.return_token_texts else None
                 ),
                 routed_experts=(
                     output.routed_experts.tolist()

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -141,6 +141,18 @@ class CompletionRequest(OpenAIBaseModel):
             "need to map generated text back to input tokens."
         ),
     )
+    return_token_texts: bool | None = Field(
+        default=None,
+        description=(
+            "If specified, the result will include per-token detokenized "
+            "strings produced by contextual incremental detokenization. "
+            "Each entry corresponds to one token and represents its text "
+            "contribution to the generated output. "
+            "Invariant: ''.join(token_texts) == text (streaming delta) "
+            "or ''.join(token_texts) == text (non-streaming). "
+            "len(token_texts) == len(token_ids) when both are requested."
+        ),
+    )
 
     cache_salt: str | None = Field(
         default=None,
@@ -316,6 +328,7 @@ class CompletionRequest(OpenAIBaseModel):
             output_kind=RequestOutputKind.DELTA
             if self.stream
             else RequestOutputKind.FINAL_ONLY,
+            return_token_texts=bool(self.return_token_texts),
             structured_outputs=self.structured_outputs,
             logit_bias=self.logit_bias,
             allowed_token_ids=self.allowed_token_ids,
@@ -466,6 +479,7 @@ class CompletionResponseChoice(OpenAIBaseModel):
         ),
     )
     token_ids: list[int] | None = None  # For response
+    token_texts: list[str] | None = None
     prompt_logprobs: list[dict[int, Logprob] | None] | None = None
     prompt_token_ids: list[int] | None = None  # For prompt
     routed_experts: list[list[list[int]]] | None = None  # [gen_len, num_layers, top_k]
@@ -507,6 +521,7 @@ class CompletionResponseStreamChoice(OpenAIBaseModel):
     # prompt tokens is put into choice to align with CompletionResponseChoice
     prompt_token_ids: list[int] | None = None
     token_ids: list[int] | None = None
+    token_texts: list[str] | None = None
 
 
 class CompletionStreamResponse(OpenAIBaseModel):

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -153,6 +153,16 @@ class CompletionRequest(OpenAIBaseModel):
             "len(token_texts) == len(token_ids) when both are requested."
         ),
     )
+    enable_speculative_decoding: bool | None = Field(
+        default=None,
+        description=(
+            "Per-request opt-in for speculative decoding. Requires the "
+            "server to have --speculative-config set. If unset/false, "
+            "proposer-produced drafts are discarded for this request. "
+            "Mutually exclusive with "
+            "structured_outputs.enable_jump_decoding."
+        ),
+    )
 
     cache_salt: str | None = Field(
         default=None,
@@ -329,6 +339,7 @@ class CompletionRequest(OpenAIBaseModel):
             if self.stream
             else RequestOutputKind.FINAL_ONLY,
             return_token_texts=bool(self.return_token_texts),
+            enable_speculative_decoding=self.enable_speculative_decoding,
             structured_outputs=self.structured_outputs,
             logit_bias=self.logit_bias,
             allowed_token_ids=self.allowed_token_ids,

--- a/vllm/entrypoints/openai/completion/serving.py
+++ b/vllm/entrypoints/openai/completion/serving.py
@@ -409,6 +409,11 @@ class OpenAIServingCompletion(OpenAIServing):
                                     if request.return_token_ids
                                     else None
                                 ),
+                                token_texts=(
+                                    output.token_texts
+                                    if request.return_token_texts
+                                    else None
+                                ),
                             )
                         ],
                     )
@@ -550,6 +555,9 @@ class OpenAIServingCompletion(OpenAIServing):
                     ),
                     token_ids=(
                         as_list(output.token_ids) if request.return_token_ids else None
+                    ),
+                    token_texts=(
+                        output.token_texts if request.return_token_texts else None
                     ),
                     routed_experts=(
                         output.routed_experts.tolist()

--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -42,6 +42,7 @@ class CompletionOutput:
     token_ids: GenericSequence[int]
     cumulative_logprob: float | None
     logprobs: SampleLogprobs | None
+    token_texts: list[str] | None = None
     routed_experts: np.ndarray | None = None  # [seq_len,layer_num,topk]
     finish_reason: str | None = None
     stop_reason: int | str | None = None

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -268,6 +268,10 @@ class SamplingParams(
     include_stop_str_in_output: bool = False
     """Whether to include the stop strings in output text."""
     output_kind: RequestOutputKind = RequestOutputKind.CUMULATIVE
+    return_token_texts: bool = False
+    """Whether to return per-token detokenized strings alongside generated
+    text.  When True the detokenizer accumulates the individual
+    ``decode_next()`` results so they can be surfaced in the response."""
     skip_clone: bool = False
     """Internal flag indicating that this SamplingParams instance is safe to
     reuse without cloning. When True, clone() will return self without
@@ -339,6 +343,7 @@ class SamplingParams(
         skip_special_tokens: bool = True,
         spaces_between_special_tokens: bool = True,
         output_kind: RequestOutputKind = RequestOutputKind.CUMULATIVE,
+        return_token_texts: bool = False,
         structured_outputs: StructuredOutputsParams | None = None,
         logit_bias: dict[int, float] | dict[str, float] | None = None,
         allowed_token_ids: list[int] | None = None,
@@ -380,6 +385,7 @@ class SamplingParams(
             skip_special_tokens=skip_special_tokens,
             spaces_between_special_tokens=spaces_between_special_tokens,
             output_kind=output_kind,
+            return_token_texts=return_token_texts,
             structured_outputs=structured_outputs,
             logit_bias=logit_bias,
             allowed_token_ids=allowed_token_ids,

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -277,6 +277,13 @@ class SamplingParams(
     """Whether to return per-token detokenized strings alongside generated
     text.  When True the detokenizer accumulates the individual
     ``decode_next()`` results so they can be surfaced in the response."""
+    enable_speculative_decoding: bool | None = None
+    """Per-request opt-in for speculative decoding. Requires the server
+    to also have a SpeculativeConfig (e.g. ``--speculative-config '{...}'``).
+    None/False = drafts produced by the proposer are discarded for this
+    request (it runs as if speculative decoding were off); True = drafts
+    are used. Mutually exclusive with
+    ``structured_outputs.enable_jump_decoding`` on the same request."""
     skip_clone: bool = False
     """Internal flag indicating that this SamplingParams instance is safe to
     reuse without cloning. When True, clone() will return self without
@@ -349,6 +356,7 @@ class SamplingParams(
         spaces_between_special_tokens: bool = True,
         output_kind: RequestOutputKind = RequestOutputKind.CUMULATIVE,
         return_token_texts: bool = False,
+        enable_speculative_decoding: bool | None = None,
         structured_outputs: StructuredOutputsParams | None = None,
         logit_bias: dict[int, float] | dict[str, float] | None = None,
         allowed_token_ids: list[int] | None = None,
@@ -391,6 +399,7 @@ class SamplingParams(
             spaces_between_special_tokens=spaces_between_special_tokens,
             output_kind=output_kind,
             return_token_texts=return_token_texts,
+            enable_speculative_decoding=enable_speculative_decoding,
             structured_outputs=structured_outputs,
             logit_bias=logit_bias,
             allowed_token_ids=allowed_token_ids,
@@ -771,6 +780,33 @@ class SamplingParams(
         self,
         speculative_config: SpeculativeConfig | None,
     ) -> None:
+        # Jump-forward decoding and speculative decoding can both be
+        # capabilities of the server, but a single request can't use both
+        # — they write to overlapping positions in the input buffer and
+        # have incompatible verification semantics.
+        if (
+            self.enable_speculative_decoding
+            and self.structured_outputs is not None
+            and self.structured_outputs.enable_jump_decoding
+        ):
+            raise ValueError(
+                "enable_speculative_decoding and "
+                "structured_outputs.enable_jump_decoding cannot both be "
+                "true on the same request — choose one."
+            )
+
+        # Reject per-request MTP opt-in against a server that has no
+        # SpeculativeConfig (no --speculative-config flag). Without it the
+        # proposer model is not loaded and the per-request flag would be a
+        # silent no-op, masking deployment-config bugs as performance issues.
+        if self.enable_speculative_decoding and speculative_config is None:
+            raise ValueError(
+                "enable_speculative_decoding=True was set on this request, "
+                "but the server has no SpeculativeConfig (start with "
+                "--speculative-config '{\"method\":\"...\",...}'). The flag "
+                "would otherwise be silently ignored."
+            )
+
         if speculative_config is None:
             return
 

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -50,6 +50,11 @@ class StructuredOutputsParams:
     disable_additional_properties: bool = False
     whitespace_pattern: str | None = None
     structural_tag: str | None = None
+    enable_jump_decoding: bool | None = None
+    """Per-request opt-in for jump-forward decoding. Requires the server
+    to also enable it via StructuredOutputsConfig.enable_jump_decoding.
+    None/False = no FF tokens for this request; True = use FF when the
+    grammar forces deterministic tokens."""
 
     _backend: str | None = field(default=None, init=False)
     """CAUTION: Should only be set by Processor._validate_structured_output"""
@@ -781,6 +786,27 @@ class SamplingParams(
         structured_outputs_config: StructuredOutputsConfig | None,
         tokenizer: TokenizerLike | None,
     ) -> None:
+        # Per-request JD opt-in requires the server to also have
+        # enable_jump_decoding=true in --structured-outputs-config.
+        # llguidance only maintains the ff-token state when the server has
+        # opted in at startup; without it, advance_ff_tokens() returns []
+        # and the per-request flag would be silently no-op. Raise loudly so
+        # deployment-config mistakes surface as 4xx, not as missing speedups.
+        if (
+            self.structured_outputs is not None
+            and self.structured_outputs.enable_jump_decoding
+            and (
+                structured_outputs_config is None
+                or not structured_outputs_config.enable_jump_decoding
+            )
+        ):
+            raise ValueError(
+                "structured_outputs.enable_jump_decoding=True was set on this "
+                "request, but the server was not started with "
+                "--structured-outputs-config '{...,\"enable_jump_decoding\":true}'. "
+                "The flag would otherwise be silently ignored."
+            )
+
         if structured_outputs_config is None or self.structured_outputs is None:
             return
 

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import cached_property
 from typing import TYPE_CHECKING
 
@@ -239,6 +239,10 @@ class SchedulerOutput:
     # The worker zeros the corresponding GPU memory before the blocks are used,
     # preventing stale NaN/data from corrupting attention or SSM computation.
     new_block_ids_to_zero: list[int] | None = None
+
+    # Jump-forward decoding: grammar-forced tokens to write to the buffer.
+    # req_id -> list of deterministic token IDs
+    jump_forward_tokens: dict[str, list[int]] = field(default_factory=dict)
 
     @classmethod
     def make_empty(cls) -> "SchedulerOutput":

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -81,6 +81,22 @@ def _request_opts_into_jump_decoding(request: Request) -> bool:
     return bool(sp.structured_outputs.enable_jump_decoding)
 
 
+def _request_opts_into_spec_decode(request: Request) -> bool:
+    """Per-request opt-in gate for speculative decoding.
+
+    Server-side SpeculativeConfig is the capability gate; this returns
+    True only when the request explicitly asked for spec drafts via
+    SamplingParams.enable_speculative_decoding. Default (None / False)
+    means proposer-produced drafts are discarded for this request,
+    matching no-spec behavior. JD and spec are mutually exclusive at the
+    request level.
+    """
+    sp = request.sampling_params
+    if sp is None:
+        return False
+    return bool(sp.enable_speculative_decoding)
+
+
 class Scheduler(SchedulerInterface):
     def __init__(
         self,
@@ -1732,6 +1748,12 @@ class Scheduler(SchedulerInterface):
                     request.spec_token_ids = []
                 continue
 
+            if not _request_opts_into_spec_decode(request):
+                # Per-request opt-out: drop proposer-produced drafts.
+                if request.spec_token_ids:
+                    request.spec_token_ids = []
+                continue
+
             # Add newly generated spec token ids to the request.
             if self.structured_output_manager.should_advance(request):
                 metadata = request.structured_output_request
@@ -1758,6 +1780,21 @@ class Scheduler(SchedulerInterface):
                 continue
 
             orig_num_spec_tokens = len(placeholder_spec_tokens)
+
+            # Per-request opt-out for speculative decoding. The async
+            # scheduling path routes drafts through this function instead
+            # of update_draft_token_ids, so the gate has to be mirrored
+            # here. Invalidate the scheduled drafts in scheduler_output
+            # directly (the local draft_token_ids list is not read
+            # downstream) by writing -1 sentinels into sched_spec_tokens
+            # and recording them as invalid. The verifier rejects -1 slots
+            # and the request falls back to single-token decode for this
+            # step.
+            if not _request_opts_into_spec_decode(request):
+                sched_spec_tokens[req_id] = [-1] * orig_num_spec_tokens
+                num_invalid_spec_tokens[req_id] = orig_num_spec_tokens
+                continue
+
             # Trim drafts to scheduled number of spec tokens
             # (needed for chunked prefill case for example).
             del spec_token_ids[orig_num_spec_tokens:]

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -7,6 +7,8 @@ from collections.abc import Iterable
 from dataclasses import replace
 from typing import Any
 
+import numpy as np
+
 from vllm import envs
 from vllm.compilation.cuda_graph import CUDAGraphStat
 from vllm.config import VllmConfig
@@ -50,13 +52,33 @@ from vllm.v1.engine import EngineCoreEventType, EngineCoreOutput, EngineCoreOutp
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.metrics.perf import ModelMetrics, PerfStats
 from vllm.v1.metrics.stats import PrefixCacheStats, SchedulerStats
-from vllm.v1.outputs import DraftTokenIds, KVConnectorOutput, ModelRunnerOutput
+from vllm.v1.outputs import (
+    DraftTokenIds,
+    KVConnectorOutput,
+    LogprobsLists,
+    ModelRunnerOutput,
+)
 from vllm.v1.request import Request, RequestStatus, StreamingUpdate
 from vllm.v1.spec_decode.metrics import SpecDecodingStats
 from vllm.v1.structured_output import StructuredOutputManager
 from vllm.v1.utils import record_function_or_nullcontext
 
 logger = init_logger(__name__)
+
+
+def _request_opts_into_jump_decoding(request: Request) -> bool:
+    """Per-request opt-in gate for jump-forward decoding.
+
+    Server-side StructuredOutputsConfig.enable_jump_decoding is the
+    capability gate; this returns True only when the request explicitly
+    asked for FF via SamplingParams.structured_outputs.enable_jump_decoding.
+    Default (None / False) means no FF tokens for the request — safe
+    behavior during a gradual rollout.
+    """
+    sp = request.sampling_params
+    if sp is None or sp.structured_outputs is None:
+        return False
+    return bool(sp.structured_outputs.enable_jump_decoding)
 
 
 class Scheduler(SchedulerInterface):
@@ -96,6 +118,11 @@ class Scheduler(SchedulerInterface):
             defaultdict(set) if include_finished_set else None
         )
         self.prev_step_scheduled_req_ids: set[str] = set()
+        # Jump-forward decoding: grammar-forced tokens pending write to buffer.
+        self.jump_decoding_enabled = (
+            vllm_config.structured_outputs_config.enable_jump_decoding
+        )
+        self.pending_ff_tokens: dict[str, list[int]] = {}
 
         # Scheduling constraints.
         self.max_num_running_reqs = self.scheduler_config.max_num_seqs
@@ -859,6 +886,16 @@ class Scheduler(SchedulerInterface):
         self.prev_step_scheduled_req_ids.clear()
         self.prev_step_scheduled_req_ids.update(num_scheduled_tokens.keys())
 
+        # Jump-forward: pass pending ff tokens for scheduled requests only.
+        # Retain ff tokens for requests not scheduled in this step.
+        jump_forward_tokens = {
+            req_id: tokens
+            for req_id, tokens in self.pending_ff_tokens.items()
+            if req_id in num_scheduled_tokens
+        }
+        for req_id in jump_forward_tokens:
+            del self.pending_ff_tokens[req_id]
+
         new_block_ids_to_zero = (
             (self.kv_cache_manager.take_new_block_ids() or None)
             if self.needs_kv_cache_zeroing
@@ -881,6 +918,7 @@ class Scheduler(SchedulerInterface):
             finished_req_ids=self.finished_req_ids,
             free_encoder_mm_hashes=self.encoder_cache_manager.get_freed_mm_hashes(),
             new_block_ids_to_zero=new_block_ids_to_zero,
+            jump_forward_tokens=jump_forward_tokens,
         )
 
         # NOTE(Kuntai): this function is designed for multiple purposes:
@@ -1344,6 +1382,7 @@ class Scheduler(SchedulerInterface):
             new_token_ids = generated_token_ids
             pooler_output = pooler_outputs[req_index] if pooler_outputs else None
             kv_transfer_params = None
+            finish_reason = None
             status_before_stop = request.status
 
             # Check for stop and update request status.
@@ -1380,10 +1419,97 @@ class Scheduler(SchedulerInterface):
                 and req_id in model_runner_output.routed_experts_dict
             ):
                 routed_experts = model_runner_output.routed_experts_dict[req_id]
-            finish_reason = None
+
+            # Extract sample logprobs if needed.
+            if (
+                request.sampling_params is not None
+                and request.sampling_params.num_logprobs is not None
+                and logprobs
+            ):
+                new_logprobs = logprobs.slice_request(req_index, len(new_token_ids))
+
+            # Jump-forward: compute deterministic tokens forced by grammar.
+            if (
+                self.jump_decoding_enabled
+                and new_token_ids
+                and not stopped
+                and self.structured_output_manager.should_advance(request)
+                and _request_opts_into_jump_decoding(request)
+            ):
+                struct_output_request = request.structured_output_request
+                assert struct_output_request is not None
+                assert struct_output_request.grammar is not None
+                if not struct_output_request.grammar.is_terminated():
+                    jd_start = time.perf_counter()
+                    ff_tokens = struct_output_request.grammar.advance_ff_tokens()
+                    jd_elapsed = time.perf_counter() - jd_start
+
+                    if ff_tokens:
+                        logger.info(
+                            "[JUMP-FWD] advance_ff_tokens for %s took %.4fs, "
+                            "returned %d tokens",
+                            req_id,
+                            jd_elapsed,
+                            len(ff_tokens),
+                        )
+                        # Append ff_tokens one by one, checking stop
+                        # conditions after each token (matching the
+                        # behavior in _update_request_with_output).
+                        for i, tok in enumerate(ff_tokens):
+                            request.append_output_token_ids(tok)
+                            new_token_ids.append(tok)
+                            stopped = check_stop(request, self.max_model_len)
+                            if stopped:
+                                ff_tokens = ff_tokens[: i + 1]
+                                break
+                        self.pending_ff_tokens[req_id] = ff_tokens
+
+                        # Extend logprobs for ff_tokens: each is
+                        # deterministic (logprob=0, all others=-inf),
+                        # mirroring what the model would produce if
+                        # the grammar bitmask allowed only one token.
+                        if new_logprobs is not None:
+                            n = len(ff_tokens)
+                            width = new_logprobs.logprob_token_ids.shape[1]
+                            # Columns 1.. use -1 as an invalid-token-id
+                            # sentinel so the downstream dict[token_id, ...]
+                            # build does not produce a spurious {0: -inf}
+                            # entry (or, worse, overwrite the column 0
+                            # logprob if the forced token itself is 0).
+                            ff_token_ids = np.full(
+                                (n, width),
+                                -1,
+                                dtype=new_logprobs.logprob_token_ids.dtype,
+                            )
+                            ff_token_ids[:, 0] = ff_tokens
+                            ff_logprobs = np.full(
+                                (n, width),
+                                -np.inf,
+                                dtype=new_logprobs.logprobs.dtype,
+                            )
+                            ff_logprobs[:, 0] = 0.0
+                            ff_ranks = np.zeros(
+                                n,
+                                dtype=new_logprobs.sampled_token_ranks.dtype,
+                            )
+                            new_logprobs = LogprobsLists(
+                                np.concatenate(
+                                    [new_logprobs.logprob_token_ids, ff_token_ids]
+                                ),
+                                np.concatenate([new_logprobs.logprobs, ff_logprobs]),
+                                np.concatenate(
+                                    [new_logprobs.sampled_token_ranks, ff_ranks]
+                                ),
+                                None,
+                            )
+
+            # Handle stop after FF so requests stopped by grammar-forced
+            # tokens (EOS/max_tokens hit inside the FF loop) go through the
+            # same cleanup as model-sampled stops.
             if stopped:
-                # Capture finish_reason BEFORE _handle_stopped_request, which may
-                # reset the status to WAITING for streaming requests that continue.
+                # Capture finish_reason BEFORE _handle_stopped_request, which
+                # may reset the status to WAITING for streaming requests that
+                # continue.
                 finish_reason = request.get_finished_reason()
                 finished = self._handle_stopped_request(request)
                 if finished:
@@ -1393,14 +1519,6 @@ class Scheduler(SchedulerInterface):
                     stopped_running_reqs.add(request)
                 else:
                     stopped_preempted_reqs.add(request)
-
-            # Extract sample logprobs if needed.
-            if (
-                request.sampling_params is not None
-                and request.sampling_params.num_logprobs is not None
-                and logprobs
-            ):
-                new_logprobs = logprobs.slice_request(req_index, len(new_token_ids))
 
             if num_nans_in_logits is not None and req_id in num_nans_in_logits:
                 request.num_nans_in_logits = num_nans_in_logits[req_id]

--- a/vllm/v1/engine/detokenizer.py
+++ b/vllm/v1/engine/detokenizer.py
@@ -45,6 +45,17 @@ class IncrementalDetokenizer:
     def get_next_output_text(self, finished: bool, delta: bool) -> str:
         return ""
 
+    def get_next_token_texts(self, delta: bool) -> list[str] | None:
+        """Return per-token detokenized strings.
+
+        When delta is True, returns only texts for tokens produced since the
+        last call.  Each entry is the contextually-detokenized contribution of
+        one token; ''.join(result) == the corresponding delta text.
+
+        Returns None when detokenization is disabled (no tokenizer).
+        """
+        return None
+
     @classmethod
     def from_new_request(
         cls,
@@ -92,6 +103,15 @@ class BaseIncrementalDetokenizer(IncrementalDetokenizer, ABC):
         # Generation data
         self.output_text = ""
 
+        # Per-token detokenized text tracking (opt-in).
+        self.return_token_texts = (
+            request.sampling_params.return_token_texts
+            if request.sampling_params is not None
+            else False
+        )
+        self.incremental_token_texts: list[str] = []
+        self.last_token_texts_offset: int = 0
+
     def update(self, new_token_ids: list[int], stop_terminated: bool) -> str | None:
         """
         Update RequestState for the request_id by:
@@ -116,7 +136,10 @@ class BaseIncrementalDetokenizer(IncrementalDetokenizer, ABC):
         stop_check_offset = len(self.output_text)
         for new_token_id in new_token_ids:
             self.token_ids.append(new_token_id)
-            self.output_text += self.decode_next(new_token_id)
+            decoded = self.decode_next(new_token_id)
+            self.output_text += decoded
+            if self.return_token_texts:
+                self.incremental_token_texts.append(decoded)
             # Support min_tokens, see https://github.com/vllm-project/vllm/pull/22014
             if self.min_tokens and self.num_output_tokens() <= self.min_tokens:
                 stop_check_offset = len(self.output_text)
@@ -162,6 +185,15 @@ class BaseIncrementalDetokenizer(IncrementalDetokenizer, ABC):
             self._last_output_text_offset = length
             return self.output_text[last_offset:length]
         return ""
+
+    def get_next_token_texts(self, delta: bool) -> list[str] | None:
+        if not self.return_token_texts:
+            return None
+        if not delta:
+            return list(self.incremental_token_texts)
+        last_offset = self.last_token_texts_offset
+        self.last_token_texts_offset = len(self.incremental_token_texts)
+        return list(self.incremental_token_texts[last_offset:])
 
 
 class FastIncrementalDetokenizer(BaseIncrementalDetokenizer):

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -412,6 +412,7 @@ class RequestState:
 
         # Prepare text and token_ids, based on delta mode
         text = self.detokenizer.get_next_output_text(finished, delta)
+        token_texts = self.detokenizer.get_next_token_texts(delta)
         if not delta:
             token_ids = self.detokenizer.output_token_ids
 
@@ -424,6 +425,7 @@ class RequestState:
             index=self.request_index,
             text=text,
             token_ids=token_ids,
+            token_texts=token_texts,
             routed_experts=routed_experts,
             logprobs=logprobs,
             cumulative_logprob=self.logprobs_processor.cumulative_logprob,

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -283,8 +283,18 @@ class StructuredOutputManager:
                         apply_bitmask = False
                     if apply_bitmask and not grammar.is_terminated():
                         accepted = grammar.accept_tokens(req_id, [token])
-                        assert accepted, (token, req_id, scheduled_spec_decode_tokens)
-                        state_advancements += 1
+                        if not accepted:
+                            # The drafter (proposer) is not grammar-constrained,
+                            # so it can propose a token the grammar forbids. The
+                            # bitmask filled for THIS position above already
+                            # excludes it, so verification will reject this draft
+                            # and (by speculative-decoding semantics) every draft
+                            # after it. Stop advancing the grammar; the remaining
+                            # positions get a full mask and are discarded after
+                            # the rejection.
+                            apply_bitmask = False
+                        else:
+                            state_advancements += 1
                     cumulative_index += 1
                 if state_advancements > 0:
                     grammar.rollback(state_advancements)

--- a/vllm/v1/structured_output/backend_guidance.py
+++ b/vllm/v1/structured_output/backend_guidance.py
@@ -165,18 +165,27 @@ class GuidanceGrammar(StructuredOutputGrammar):
         if self.ll_matcher.is_stopped():
             return True
 
-        # TODO - Add jump decoding support in the future:
-        # self.ll_matcher.compute_ff_bytes() - this should always work
-        # self.ll_matcher.compute_ff_tokens() - this only works for
-        #   "canonical" tokenizers
-        # For conversion between the two, see
-        # https://github.com/guidance-ai/llguidance/blob/main/docs/fast_forward.md
-
         r = self.ll_matcher.consume_tokens(tokens)
 
         self.check_error()
 
         return r
+
+    def advance_ff_tokens(self) -> list[int]:
+        """Compute deterministic fast-forward tokens from the grammar.
+
+        After accepting a token, the grammar may force a sequence of
+        tokens that don't require model inference. This returns those
+        tokens and advances the matcher past them.
+        """
+        if self.ll_matcher.is_stopped():
+            return []
+
+        ff_tokens = self.ll_matcher.compute_ff_tokens()
+        if ff_tokens:
+            self.ll_matcher.consume_tokens(ff_tokens)
+            self.check_error()
+        return ff_tokens
 
     def validate_tokens(self, tokens: list[int]) -> list[int]:
         """Checks if the list of tokens are accepted by the parser in sequence.

--- a/vllm/v1/structured_output/backend_types.py
+++ b/vllm/v1/structured_output/backend_types.py
@@ -88,6 +88,14 @@ class StructuredOutputGrammar(ABC):
             bool: True if the process is terminated, False otherwise.
         """
 
+    def advance_ff_tokens(self) -> list[int]:
+        """Computes fast-forward (deterministic) tokens from the grammar.
+
+        Returns tokens that the grammar forces without needing model
+        inference. Default implementation returns empty list.
+        """
+        return []
+
     @abstractmethod
     def reset(self):
         """

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1387,6 +1387,23 @@ class GPUModelRunner(
                 if orig != req_state.prev_num_draft_len:
                     req_state.prev_num_draft_len = orig
 
+            # Jump-forward: write grammar-forced tokens to the buffer.
+            ff_tokens = scheduler_output.jump_forward_tokens.get(req_id)
+            if ff_tokens:
+                start_idx = self.input_batch.num_tokens_no_spec[req_index]
+                end_idx = start_idx + len(ff_tokens)
+                assert end_idx <= self.max_model_len, (
+                    f"Jump-forward tokens exceed max_model_len "
+                    f"({end_idx} > {self.max_model_len}) for request {req_id}."
+                )
+                self.input_batch.token_ids_cpu[req_index, start_idx:end_idx] = ff_tokens
+                # Mark as token IDs (not embeddings) so prompt_embeds-enabled
+                # runs preprocess these positions as token IDs, matching the
+                # sampled-token path above.
+                self.input_batch.is_token_ids[req_index, start_idx:end_idx] = True
+                self.input_batch.num_tokens_no_spec[req_index] = end_idx
+                req_state.output_token_ids.extend(ff_tokens)
+
         # Add the new or resumed requests to the persistent batch.
         # The smaller empty indices are filled first.
         for request in reqs_to_add:


### PR DESCRIPTION
## Summary

Three additive features on top of clean v0.21.0, stacked so each commit is independently reviewable and revertible. All three are per-request opt-in: enabling the capability at server start is a no-op until a client sets the corresponding flag on the request.

| # | Commit | What it adds |
|---|--------|--------------|
| 1 | `17815eb` | `return_token_texts` — per-token detokenized strings in OpenAI responses |
| 2 | `40dda20` | Jump-forward decoding (PR #36142) ported to v0.21.0, per-request opt-in |
| 3 | `1e052ae` | Per-request opt-in for speculative decoding (MTP), incl. JD/MTP request-level mutex |

## 1 — `17815eb` feat: add return_token_texts for per-token incremental detokenization

Adds a `return_token_texts: bool` field on both OpenAI request models and on `SamplingParams`. When true, the v1 detokenizer captures each `decode_next()` result; both streaming and non-streaming responses include a `token_texts: list[str]` parallel to `token_ids`, with the invariant `''.join(token_texts) == delta.content` (streaming) or `== message.content` (non-streaming).

Touches: chat/completion `protocol.py` + `serving.py`, `vllm/outputs.py`, `sampling_params.py`, `v1/engine/detokenizer.py`, `v1/engine/output_processor.py`. No server-side configuration required.

Client usage via `extra_body`:

```json
{ "messages": [...], "return_token_texts": true }
```

## 2 — `40dda20` feat(scheduler): jump-forward decoding for structured outputs (per-request opt-in)

Port of upstream PR #36142 onto v0.21.0, restructured so it's per-request opt-in from the first scheduler step rather than a server-wide flag.

**Mechanism.** After each scheduler step, if the grammar deterministically forces the next N tokens (e.g. inside a known JSON key/value, after an unambiguous regex anchor), the scheduler appends `llguidance.compute_ff_tokens()`'s output directly to the request's `output_token_ids` and skips the model forward pass for those tokens. Tokens propagate to workers via `SchedulerOutput.jump_forward_tokens`.

**Per-request gate.** A new `StructuredOutputsParams.enable_jump_decoding` field. Drafts for non-opted-in requests are ignored at scheduling time, so the FF computation is bypassed entirely for them.

Included in the same commit:

- Bounds check + `is_token_ids` mask fix on the model runner's FF write.
- Stop-cleanup runs after FF emission so EOS / max_tokens hit inside the FF loop go through `_handle_stopped_request` and `_free_request` correctly.
- `-1` sentinel for FF logprob padding (prevents spurious `{0: -inf}` entries in the per-position logprob dict).
- INFO-level `[JUMP-FWD]` log per `advance_ff_tokens` call with timing and token count.
- Unit tests for opt-in / opt-out and the stop-cleanup paths.

**Server-side activation** (capability load):

```
--structured-outputs-config '{"backend":"guidance","enable_jump_decoding":true,...}'
```

**Client usage** (nested inside `structured_outputs`):

```json
{
  "messages": [...],
  "structured_outputs": {
    "json": "...",
    "enable_jump_decoding": true
  }
}
```

## 3 — `1e052ae` feat: per-request opt-in for speculative decoding (MTP)

Adds `SamplingParams.enable_speculative_decoding` (`bool | None`). When the server is configured with a `SpeculativeConfig` (e.g. MTP), the proposer still runs over the whole batch, but proposer-produced drafts are discarded for requests that did not explicitly opt in — those requests behave as if speculative decoding were off.

Two scheduler gate points for full coverage of vLLM's two draft-attachment paths:

- `update_draft_token_ids` (sync / `post_step` path): clears `request.spec_token_ids` for non-opted-in requests.
- `update_draft_token_ids_in_output` (async / `batch_queue` path): writes `[-1] * num_spec_tokens` directly into `scheduler_output.scheduled_spec_decode_tokens[req_id]` and records the slots as invalid so the grammar bitmask / verification path rejects them. Without this second gate, the auto-enable of `async_scheduling` (triggered by MTP being in `EagleModelTypes`) silently bypasses the per-request flag.

**Mutex.** Setting `enable_speculative_decoding=true` and `structured_outputs.enable_jump_decoding=true` on the same request is rejected by `SamplingParams._validate_spec_decode` — they write to overlapping positions in `token_ids_cpu` and have incompatible verification semantics. Server-level `enable_jump_decoding` + `--speculative-config` can now coexist; mutual exclusion is enforced per-request only.

**OpenAI plumbing.** `enable_speculative_decoding` is a top-level field on `ChatCompletionRequest` / `CompletionRequest` and forwarded to `SamplingParams` via `to_sampling_params()`, so clients set it directly via `extra_body` without nesting.

**Server-side activation** (capability load):

```
--speculative-config '{"method":"mtp","model":"google/gemma-4-31B-it-assistant","num_speculative_tokens":7,"draft_tensor_parallel_size":1}'
```

**Client usage**:

```json
{ "messages": [...], "enable_speculative_decoding": true }
```

## Combined deployment

A single server can advertise both capabilities — clients pick which to use per request:

```
--structured-outputs-config '{"backend":"guidance","enable_jump_decoding":true,...}'
--speculative-config         '{"method":"mtp","model":"google/gemma-4-31B-it-assistant","num_speculative_tokens":7,...}'
```

| Request flags | Behavior |
|---|---|
| neither | plain inference; drafts discarded if MTP loaded |
| `enable_jump_decoding=true` | JD path, no spec |
| `enable_speculative_decoding=true` | MTP path, no JD |
| both | 400 from `_validate_spec_decode` mutex |

## Tests

- `tests/v1/core/test_scheduler.py`: covers FF injection, EOS/max-tokens stop with cleanup assertions, FF-logprob structure, JD opt-in/opt-out, MTP opt-in/opt-out (both sync and async draft paths), and the JD/MTP request-level mutex.
- `tests/v1/core/utils.py`: `create_scheduler(enable_jump_decoding=...)` knob added for the scheduler tests.
